### PR TITLE
add impress-console class to previews' body.

### DIFF
--- a/js/impressConsole.js
+++ b/js/impressConsole.js
@@ -208,12 +208,16 @@
         };
         
         var consoleOnLoad = function() {
-        
-            var slideView = consoleWindow.document.getElementById('slideView');
-            var preView = consoleWindow.document.getElementById('preView');
+	        var slideView = consoleWindow.document.getElementById('slideView');
+	        var preView = consoleWindow.document.getElementById('preView');
 
-            slideView.contentDocument.body.classList.add('impressConsole');
-            preView.contentDocument.body.classList.add('impressConsole');
+	        slideView.addEventListener('load', function() {
+		        slideView.contentDocument.body.classList.add('impress-console');
+	        });
+
+	        preView.addEventListener('load', function() {
+		        preView.contentDocument.body.classList.add('impress-console');
+	        });
         };        
     
         var open = function() {


### PR DESCRIPTION
Hey,

Related to #2 and your patch.

Your `impressConsole` class was added before any content had the chance to be loaded. So it was overridden.
This patch ensure `impress-console` is present.
